### PR TITLE
feat(nix): add u-boot configuration to automatically boot qemu

### DIFF
--- a/pkgs/u-boot/u-boot.nix
+++ b/pkgs/u-boot/u-boot.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation rec {
         make qemu_arm64_defconfig
         echo "CONFIG_TFABOOT=y" >> .config
         echo "CONFIG_SYS_TEXT_BASE=0x60000000" >> .config
+        echo "CONFIG_BOOTDELAY=0" >> ./.config 
+        echo "CONFIG_BOOTCOMMAND=\"go 0x50000000\"" >> .config
         make
     '';
     


### PR DESCRIPTION
This PR introduces the changes needed to the u-boot nix recipe to automate the testing process. The implemented changes allow to automatically boot Qemu without the need to insert any command to make u-boot jump to where the image was loaded. This replaces the following step:

Make u-boot jump to where the bao image was loaded:
```
go 0x50000000
```


Please review this PR and provide your feedback.